### PR TITLE
wPOKT: fix token decimals

### DIFF
--- a/packages/wPOKT/contracts/wPOKT.sol
+++ b/packages/wPOKT/contracts/wPOKT.sol
@@ -27,7 +27,7 @@ contract wPOKT is IERC20 {
 
     string public constant name = "Wrapped POKT Token";
     string public constant symbol = "wPOKT";
-    uint8 public constant decimals = 18;
+    uint8 public constant decimals = 6;
 
     address public minter;
     uint256 public totalSupply;

--- a/packages/wPOKT/test/wPOKT.js
+++ b/packages/wPOKT/test/wPOKT.js
@@ -54,7 +54,7 @@ contract('wPOKT', ([_, minter, newMinter, holder1, holder2, newHolder]) => {
   it('set up the token correctly', async () => {
     assert.equal(await wpokt.name(), 'Wrapped POKT Token', 'token: name')
     assert.equal(await wpokt.symbol(), 'wPOKT', 'token: symbol')
-    assert.equal(await wpokt.decimals(), '18', 'token: decimals')
+    assert.equal(await wpokt.decimals(), '6', 'token: decimals')
 
     assertBn(await wpokt.totalSupply(), tokenAmount(300))
     assertBn(await wpokt.balanceOf(holder1), tokenAmount(100))


### PR DESCRIPTION
wPOKT is going to be a 6 decimals token, just like USDC. Updating the contract accordingly.