### PR TITLE
buidler: fix `deploy` task

### DIFF
--- a/packages/wPOKT/buidler.config.js
+++ b/packages/wPOKT/buidler.config.js
@@ -6,7 +6,7 @@ usePlugin('@nomiclabs/buidler-truffle5')
 usePlugin('buidler-local-networks-config-plugin')
 
 task('deploy', 'Deploy wPOKT')
-  .addParam('owner', "wPOKT owner")
+  .addParam('minter', 'wPOKT minter')
   .setAction(deploy)
 
 module.exports = {

--- a/packages/wPOKT/buidler/cli.js
+++ b/packages/wPOKT/buidler/cli.js
@@ -1,9 +1,9 @@
 const inquirer = require('inquirer')
 const { calculateContractAddress } = require('./utils')
 
-async function deploy({ owner }) {
-  if (!web3.utils.isAddress(owner)) {
-    console.log('Error: --owner must be an Ethereum address')
+async function deploy({ minter }) {
+  if (!web3.utils.isAddress(minter)) {
+    console.log('Error: --minter must be an Ethereum address')
     return
   }
 
@@ -27,7 +27,7 @@ async function deploy({ owner }) {
   }])
 
   if (confirmed) {
-    await wPOKT.new(migratorAddr)
+    await wPOKT.new(minter)
 
     const deployedwPOKT = await wPOKT.at(wpoktAddr)
 


### PR DESCRIPTION
Updated the param `owner` to `minter` and also replaced `migratorAddr` with the actual minter address. 